### PR TITLE
FlexRAN Initial commit

### DIFF
--- a/flexran-base
+++ b/flexran-base
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+function exit_error() {
+    local msg="$1"; shift
+    local code="$1"; shift
+    if [ -z "$code" ]; then
+        code=1
+    fi
+    echo '{"recipient":{"type":"all","id":"all"},"user-object":{"error": "'$msg'"}}' >msgs/tx/error
+    echo "$msg"
+    exit $code
+}
+
+function dump_runtime() {
+    echo env:
+    env
+    echo
+    echo "args: $@"
+    echo
+    echo "pwd:"
+    /bin/pwd
+    echo
+    echo "ls -alR:"
+    ls -alR
+    echo
+    echo "hostname: `hostname`"
+    echo
+    echo filesystems:
+    mount
+    echo
+    echo "ls -l /dev/hugepages"
+    /bin/ls -l /dev/hugepages
+    echo
+    echo "/proc/meminfo"
+    cat /proc/meminfo
+    echo
+    echo netdevs:
+    ls -l /sys/class/net
+    echo
+    echo ip a:
+    ip a
+    echo
+    echo "per-node-hugepages:"
+    for n in 0 1; do
+        path="/sys/devices/system/node/node$n/hugepages/hugepages-1048576kB"
+        echo $path
+        for i in `/bin/ls -1 $path`; do
+            echo $i:
+            cat $path/$i
+        done
+    done
+    echo "cpumask"
+    taskset -pc $$
+}
+
+function validate_label() {
+    id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
+    re='^[1-9][0-9]*$'
+    if [[ ! "$id" =~ $re ]]; then
+        exit_error "ID from label $RS_CS_LABEL must a be a positive interger"
+    fi
+}
+
+function validate_sw_prereqs() {
+    local missing=""
+    local bail=0
+    echo "Checking for SW deps"
+    bin="getopt"
+    if $bin -V >/dev/null 2>&1; then
+        echo "Found $bin"
+    else
+        bail=1
+        missing+=" $bin"
+    fi
+    # ip does not like -h
+    bin="ip"
+    if $bin a >/dev/null 2>&1; then
+        echo "Found $bin"
+    else
+        bail=1
+        missing+=" $bin"
+    fi
+    if [ $bail -eq 1 ]; then
+        exit_error "Could not find bin: $missing"
+    fi
+}
+

--- a/flexran-client
+++ b/flexran-client
@@ -1,0 +1,287 @@
+#!/bin/bash
+
+#######################################################################################
+# Crucible Flexran client RUN function.
+#   This module orchestrates L1 and Testmac processes.
+#   It waits for Testmac to finish testing and then shuts down the processes.
+#
+#   'test-file' mode: Testmac exec's a list of tests specified in a test config file
+#                     i.e test_file=/opt/flexran/tests/nr5g/fd/testmac_fd_mu0_5mhz.cfg.
+#
+#   'user-cmd' mode:  Testmac exec's a user-provided command likely for a single test.
+#                     i.e "run 2 1 100 1001"
+#######################################################################################
+
+FLEXRAN_LOG_FILE=flexran-client.log
+
+exec >$FLEXRAN_LOG_FILE
+exec 2>&1
+
+. /usr/bin/flexran-base || (echo "/usr/bin/flexran-base not found"; exit 1)
+dump_runtime
+validate_label
+validate_sw_prereqs
+
+export FLEXRAN_ROOT=/opt/flexran
+export FLEXRAN_L1_DIR=$FLEXRAN_ROOT/bin/nr5g/gnb/l1
+export FLEXRAN_L2_DIR=$FLEXRAN_ROOT/bin/nr5g/gnb/testmac
+L1_PIPE=/tmp/flexran
+L2_PIPE=/tmp/testmac
+FLEXRAN_RESULT_FILE=l1_mlog_stats.txt
+FIRST_RESULT_WAIT_SEC=180
+COMPLETION_SIGNATURE="All Tests Completed"
+FLEXRAN_MIN_WCPUS=9
+L1_CFG_FILE=$FLEXRAN_L1_DIR/phycfg_timer.xml
+TESTMAC_CFG_FILE=$FLEXRAN_L2_DIR/testmac_cfg.xml
+
+test_file="none"
+fec_mode="hw"
+user_cmd="version"
+usr1=""
+usr2=""
+usr3=""
+usr4=""
+usr5=""
+
+function init_mount_fs {
+    # Flexran S/W is ~100GB. In development, we host mount it. Now, link it to the desired filepaths.
+    ln -s /tmp/opt/flexran /opt/flexran
+    ln -s /tmp/opt/intel /opt/intel
+    ln -s /tmp/opt/dpdk-20.11 /opt/dpdk-20.11
+    ln -s /tmp/opt/configure_cfg_files.sh /opt/configure_cfg_files.sh
+    ln -s /tmp/opt/flexran_env_vars.sh /opt/flexran_env_vars.sh
+}
+
+function set_fec_mode {
+    if [ "$fec_mode" == "hw" ]; then
+        if [ -z "$PCIDEVICE_INTEL_COM_INTEL_FEC_5G" ]; then
+            exit_error "PCIDEVICE_INTEL_COM_INTEL_FEC_5G is not defined. This must be defined to run flexran HW FEC"
+        fi
+        sed -i "s#<dpdkBasebandDevice>.*</dpdkBasebandDevice>#<dpdkBasebandDevice>${PCIDEVICE_INTEL_COM_INTEL_FEC_5G}</dpdkBasebandDevice>#" $L1_CFG_FILE
+        sed -i 's#<dpdkBasebandFecMode>.*</dpdkBasebandFecMode>#<dpdkBasebandFecMode>1</dpdkBasebandFecMode>#' $L1_CFG_FILE
+    else
+        sed -i 's#<dpdkBasebandFecMode>.*</dpdkBasebandFecMode>#<dpdkBasebandFecMode>0</dpdkBasebandFecMode>#' $L1_CFG_FILE
+    fi
+ }
+
+function pin_cores {
+    # Example: WORKLOAD_CPUS=11,12,13,14,15
+    if [ $(echo "$WORKLOAD_CPUS" | awk -F "," '{print NF-1}') -lt $FLEXRAN_MIN_WCPUS ]; then
+        exit_error "Not enough CPUS. Flexran requires $FLEXRAN_MIN_CPUS or more CPUs"
+    fi
+
+    n=1
+    IFS=","
+
+    # TBD: take NUMA locality into account
+    for C in $WORKLOAD_CPUS
+    do
+        if [ $n == 1 ]; then
+            sed -i "s#<systemThread>.*,.*,.*</systemThread>#<systemThread>${C}, 0, 0</systemThread>#" $L1_CFG_FILE
+        elif [ $n == 2 ]; then
+            sed -i "s#<timerThread>.*,.*,.*</timerThread>#<timerThread>${C}, 6, 0</timerThread>#" $L1_CFG_FILE
+        elif [ $n == 3 ]; then
+            sed -i "s#<FpgaDriverCpuInfo>.*,.*,.*</FpgaDriverCpuInfo>#<FpgaDriverCpuInfo>${C}, 96, 0</FpgaDriverCpuInfo>#" $L1_CFG_FILE
+        elif [ $n == 4 ]; then
+            sed -i "s#<FrontHaulCpuInfo>.*,.*,*</FrontHaulCpuInfo>#<FrontHaulCpuInfo>${C}, 86, 0</FrontHaulCpuInfo>#" $L1_CFG_FILE
+        elif [ $n == 5 ]; then
+            sed -i "s#<radioDpdkMaster>.*,.*,.*</radioDpdkMaster>#<radioDpdkMaster>${C}, 99, 0</radioDpdkMaster>#" $L1_CFG_FILE
+        elif [ $n == 6 ]; then
+            sed -i "s#<wlsRxThread>.*,.*,.*</wlsRxThread>#<wlsRxThread>${C}, 90, 0</wlsRxThread>#" $TESTMAC_CFG_FILE
+        elif [ $n == 7 ]; then
+            sed -i "s#<systemThread>.*,.*,.*</systemThread>#<systemThread>${C}, 0, 0</systemThread>#" $TESTMAC_CFG_FILE
+        elif [ $n == 8 ]; then
+            sed -i "s#<runThread>.*,.*,.*</runThread>#<runThread>${C}, 89, 0</runThread>#" $TESTMAC_CFG_FILE
+        elif [ $n == 9 ]; then
+            sed -i "s#<urllcThread>.*,.*,.*</urllcThread>#<urllcThread>${C}, 90, 0</urllcThread>#" $TESTMAC_CFG_FILE
+            break
+        else
+            break
+        fi
+        n=$((n+1))
+    done
+ }
+
+function install_flexran_pic {
+   # To enable running flexran from current directory
+   cp /usr/bin/flexran-pic-l1 .
+   cp /usr/bin/flexran-pic-l2 .
+   cp -r $FLEXRAN_L1_DIR/table .
+}
+
+function remove_flexran_pic {
+   rm flexran-pic-l1 
+   rm flexran-pic-l2 
+   rm -fr table 
+}
+
+function start_l1 {
+    echo -e "\nCRU: Start L1"
+
+    # Launch L1 process in background. 
+    # To get around L1 process exits as soon as its stdin is closed as a result of 
+    # runnning in background, redirect its stdin to a pipe. 
+    if [ -p  $L1_PIPE ]; then
+       rm $L1_PIPE
+    fi
+    mkfifo $L1_PIPE
+    tail -f $L1_PIPE | /usr/bin/flexran-run-pic 5G &
+    sleep 20    # 10sec is recommended by Intel, but we are generous.
+}
+
+function stop_l1 {
+    echo "exit" > $L1_PIPE
+    sleep 5     # Give time for output to fully drained
+}
+
+function start_testmac {
+    echo -e "\nCRU: Start TESTMAC"
+
+    # Launch Testmac process in background. Redirect stdin to a pipe.  See L1 note.
+    if [ -p  $L2_PIPE ]; then
+       rm $L2_PIPE
+    fi
+    mkfifo $L2_PIPE
+    tail -f $L2_PIPE| TESTFILE=$test_file  /usr/bin/flexran-run-pic 5G &
+    if [ "$test_file" == "none" ]; then
+        sleep 5
+        user_cmd="${usr1} ${usr2} ${usr3} ${usr4} ${usr5}"
+        echo "$user_cmd" > $L2_PIPE
+        echo -e "\nCRU: testmac user_cmd: " $user_cmd
+    fi
+}
+
+function stop_testmac {
+    echo "exit" > $L2_PIPE
+}
+
+function flush_testmac {
+    # Send harmless 'version' commands to flush its stdout.
+    while true;
+    do
+       sleep 2
+       echo "version" > $L2_PIPE
+    done
+}
+
+# Let's do works
+
+if [ -z "$WORKLOAD_CPUS" ]; then
+    exit_error "WORKLOAD_CPUS is not defined.  This must be defined to run flexran"
+else
+    echo "WORKLOAD_CPUS: $WORKLOAD_CPUS"
+fi
+if [ -z "$HK_CPUS" ]; then
+    exit_error "HK_CPUS is not defined.  This must be defined to run flexran"
+else
+    echo "HK_CPUS: $HK_CPUS"
+fi
+
+longopts="fec-mode:,test-file:,log-test:,usr1:,usr2:,usr3:,usr4:,usr5:"
+opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
+if [ $? -ne 0 ]; then
+    exit_error "Unrecognized option specified"
+fi
+eval set -- "$opts";
+echo -e "\nCRU: opts= " $opts
+while true; do
+    case "$1" in
+        --fec-mode)
+            shift;
+            fec_mode=$1
+            if [ "$fec_mode" != "hw" ] && [ "$fec_mode" != "sw" ]; then
+                echo "Invalid fec-mode:$1"
+                fec_mode="hw"
+            fi
+            shift;
+            ;;
+        --usr1)
+            # Ex:  --usr1='run' --usr2='2' --usr3='0' --usr4='5' --usr5='12001'
+            shift;
+            usr1=$1
+            shift;
+            ;;
+        --usr2)
+            shift;
+            usr2=$1
+            shift;
+            ;;
+        --usr3)
+            shift;
+            usr3=$1
+            shift;
+            ;;
+        --usr4)
+            shift;
+            usr4=$1
+            shift;
+            ;;
+        --usr5)
+            shift;
+            usr5=$1
+            shift;
+            ;;
+        --test-file)
+            # Example: test_file=/opt/flexran/tests/nr5g/fd/testmac_fd_mu0_5mhz.cfg
+            shift;
+            test_file=$1
+            echo "test-file=$test_file"
+            shift;
+            ;;
+        --log-test)
+            # applicable to post processing only
+            shift;
+            shift;
+            ;;
+        --)
+            shift;
+            break
+            ;;
+        *)
+            exit_error "Unsupport option $1"
+            break
+            ;;
+    esac
+done
+echo "\nCRU:Use fec-mode=$fec_mode"
+
+init_mount_fs
+set_fec_mode
+pin_cores
+install_flexran_pic
+date +%s.%N >begin.txt
+start_l1
+start_testmac
+# Poll for the result file to appear, 120sec max. 
+total_wait=0
+while [ $total_wait -le $FIRST_RESULT_WAIT_SEC ]
+do
+  if [ ! -f $FLEXRAN_RESULT_FILE ]; then
+     total_wait=$((total_wait+10))
+     sleep 10
+     echo -e "\nCRU: Waited for results $total_wait seconds"
+  else
+     break
+  fi
+done
+# Poll for completion 
+error_status="None"
+if [ $total_wait -ge $FIRST_RESULT_WAIT_SEC ]; then
+    echo -e "\nCRU: Timeout waiting for results"
+    error_status="Timeout"
+else
+    echo -e "\nCRU: Waiting for results to drain"
+    # Kick Testmac to flush its stdout until the completion verbiage comes out
+    flush_testmac &
+    ( tail -f -n0 $FLEXRAN_LOG_FILE & ) | grep -q "$COMPLETION_SIGNATURE"
+fi
+echo  -e "\nCRU: Finish, error:$error_status. Stop TESTMAC and L1"
+stop_testmac
+stop_l1
+date +%s.%N >end.txt
+remove_flexran_pic
+# Kill the subproceses e.g flush_testmac and anything else
+kill $(jobs -p)
+# That's all folks
+
+

--- a/flexran-pic-l1
+++ b/flexran-pic-l1
@@ -1,0 +1,124 @@
+#######################################################################
+#
+# GPL LICENSE SUMMARY
+# 
+#   Copyright(c) 2007-2020 Intel Corporation. All rights reserved.
+# 
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of version 2 of the GNU General Public License as
+#   published by the Free Software Foundation.
+# 
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   General Public License for more details.
+# 
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+#   The full GNU General Public License is included in this distribution
+#   in the file called LICENSE.GPL.
+# 
+#   Contact Information:
+#   Intel Corporation
+# 
+#  version: RefPHY-21.03
+#
+#######################################################################
+#!/bin/bash
+#echo off
+export RTE_WLS=$FLEXRAN_ROOT/wls_mod
+
+l1Binary=$FLEXRAN_L1_DIR/l1app
+phycfg_xml_file=
+xrancfg_xml_file=
+MY_DIR=`pwd`
+WLS_DPDK_MODE=1
+huge_folder="/mnt/huge"
+MACHINE_TYPE=`uname -m`
+
+if [ "x"$1 = "x-e" ]; then
+    phycfg_xml_file=$FLEXRAN_L1_DIR/phycfg_timer.xml
+    echo "TIMER Mode"
+else
+    echo "Invlaid mode. Options are - ./l1.sh followed by:"
+    echo "-e: Timer Mode"
+    echo "-fb: Radio mode with Ferry Bridge - Sub3 20Mhz"
+    echo "-rsub6: Radio mode with Terasic Front Hual FPGA - Sub6 100Mhz"
+    echo "-rmmw: Radio mode with Terasic Front Hual FPGA - MMWave"
+    echo "-xran: Radio mode with XRAN - Sub6 100Mhz"
+    echo "-xranmmw: Radio mode with XRAN - mmWave 100Mhz"
+    echo "-xranmmimo: Radio mode with XRAN - Massive MIMO"
+    echo "-xranurllc: Radio mode with XRAN - URLLC GNB"
+    echo "-xranurllctue: Radio mode with XRAN - URLLC TestUE"
+    exit -1
+fi
+
+ulimit -c unlimited
+
+if [ ${MACHINE_TYPE} == 'x86_64' ]; then
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RTE_WLS:$FLEXRAN_ROOT/libs/cpa/bin
+
+    if [ $WLS_DPDK_MODE = "0" ]; then
+        echo Non DPDK WLS MODE
+        grep Huge /proc/meminfo
+        [ -d "$huge_folder" ] || mkdir -p $huge_folder
+        if ! mount | grep $huge_folder; then
+            mount none $huge_folder -t hugetlbfs -o rw,mode=0777
+        fi
+    else
+        echo DPDK WLS MODE
+    fi
+
+    ulimit -c unlimited
+    echo 1 > /proc/sys/kernel/core_uses_pid
+    sysctl -w kernel.sched_rt_runtime_us=-1
+    sysctl -w kernel.shmmax=2147483648
+    sysctl -w kernel.shmall=2147483648
+    chkconfig --level 12345 irqbalance off
+    echo 0 > /proc/sys/kernel/nmi_watchdog
+    echo 1 > /sys/module/rcupdate/parameters/rcu_cpu_stall_suppress
+
+    for i in ` ls /proc/irq |grep -v default_smp_affinity | grep -v 0 |grep -v 2 `
+    do
+        echo 1 > /proc/irq/$i/smp_affinity
+    done
+
+    if [ $WLS_DPDK_MODE = "0" ]; then
+        lsmod | grep wls >& /dev/null
+        if [ $? -eq 0 ]; then
+            rmmod wls
+        fi
+
+        insmod $RTE_WLS/wls.ko
+    fi
+else
+    echo "Machine type is not supported $MACHINE_TYPE"
+    exit -1
+fi
+
+cd $MY_DIR
+if [ -f "$phycfg_xml_file" ]; then
+    echo "using configuration file $phycfg_xml_file"
+    l1Cmd="$l1Binary table 0 1 --cfgfile=$phycfg_xml_file"
+else
+    echo "configuration file $phycfg_xml_file is not found"
+    exit 1
+fi
+
+if [ -f "$xrancfg_xml_file" ]; then
+    echo "using configuration file $xrancfg_xml_file"
+    l1Cmd="$l1Binary table 0 1 --cfgfile=$phycfg_xml_file --xranfile=$xrancfg_xml_file"
+fi
+
+echo ">> Running... "${l1Cmd}
+
+eval $l1Cmd
+
+echo -e "\nCRU: invoke: " "$l1Cmd"
+
+echo "Cleanup after [PID] $BASHPID"
+if [ $WLS_DPDK_MODE = "0" ]; then
+    rm -f $huge_folder
+fi
+exit 0

--- a/flexran-pic-l2
+++ b/flexran-pic-l2
@@ -1,0 +1,60 @@
+#######################################################################
+#
+# GPL LICENSE SUMMARY
+# 
+#   Copyright(c) 2007-2020 Intel Corporation. All rights reserved.
+# 
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of version 2 of the GNU General Public License as
+#   published by the Free Software Foundation.
+# 
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   General Public License for more details.
+# 
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+#   The full GNU General Public License is included in this distribution
+#   in the file called LICENSE.GPL.
+# 
+#   Contact Information:
+#   Intel Corporation
+# 
+#  version: RefPHY-21.03
+#
+#######################################################################
+cp $FLEXRAN_L2_DIR/testmac_cfg.xml .
+
+export RTE_WLS=$FLEXRAN_ROOT/wls_mod
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RTE_WLS
+
+MACHINE_TYPE=`uname -m`
+
+if [ ${MACHINE_TYPE} == 'x86_64' ]; then
+
+	ulimit -c unlimited
+	echo 1 > /proc/sys/kernel/core_uses_pid
+
+	sysctl -w kernel.sched_rt_runtime_us=-1
+	sysctl -w kernel.shmmax=2147483648
+	sysctl -w kernel.shmall=2147483648
+	chkconfig --level 12345 irqbalance off
+	echo 0 > /proc/sys/kernel/nmi_watchdog
+	echo 1 > /sys/module/rcupdate/parameters/rcu_cpu_stall_suppress
+
+#	for i in ` ls /proc/irq |grep -v default_smp_affinity | grep -v 0 |grep -v 2 `
+#	do
+#		cat /proc/irq/$i/smp_affinity
+#	done
+fi
+
+echo start 5GNR Test MAC
+if [ "$1" = "-g" ]; then
+    shift
+    gdb-ia --args $FLEXRAN_L2_DIR/testmac DIR_WIRELESS_TEST=$DIR_WIRELESS_TEST_5G $@
+else
+    $FLEXRAN_L2_DIR/testmac DIR_WIRELESS_TEST=$DIR_WIRELESS_TEST_5G $@
+    echo -e "\nCRU: invoke: " "$FLEXRAN_L2_DIR/testmac DIR_WIRELESS_TEST=$DIR_WIRELESS_TEST_5G $@"
+fi

--- a/flexran-post-process
+++ b/flexran-post-process
@@ -1,0 +1,137 @@
+#!/usr/bin/perl
+## -*- mode: perl; indent-tabs-mode: nil; perl-indent-level: 4 -*-
+## vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=perl
+## crucible get metric --source flexran --type {UL, DL} --period <> --begin <> --end <> --breakout type
+
+use strict;
+use warnings;
+use JSON::XS;
+use Data::Dumper;
+use Getopt::Long;
+
+BEGIN {
+    if (!(exists $ENV{'TOOLBOX_HOME'} && -d "$ENV{'TOOLBOX_HOME'}/perl")) {
+	print "This script requires libraries that are provided by the toolbox project.\n";
+	print "Toolbox can be acquired from https://github.com/perftool-incubator/toolbox and\n";
+	print "then use 'export TOOLBOX_HOME=/path/to/toolbox' so that it can be located.\n";
+	exit 1;
+    }
+}
+use lib "$ENV{'TOOLBOX_HOME'}/perl";
+use toolbox::json;
+use toolbox::metrics;
+
+my $ignore;
+my %times;
+my $test_file_mode="";
+my $log_test;
+GetOptions ("test-file=s" => \$test_file_mode,
+            "fec-mode=s" => \$ignore,
+            "usr1=s" => \$ignore,
+            "usr2=s" => \$ignore,
+            "usr3=s" => \$ignore,
+            "usr4=s" => \$ignore,
+            "usr5=s" => \$ignore,
+            "log-test=s" => \$log_test
+            );
+
+#
+# Extract begin/end timestamps recorded by the flexran run.
+#
+foreach my $i (qw(begin end)) {
+    my $file = $i . ".txt";
+    open(FH, $file) || die "Could not open " . $file;
+    $times{$i} = int (<FH> * 1000);
+    close FH;
+}
+
+my $primary_metric = 'DL';
+my $metric_data_name;
+my %names = ();
+my $num_sample=0;
+my %ul_desc = ('source' => 'flexran', 'class' => 'count', 'type' => 'UL');
+my %dl_desc = ('source' => 'flexran', 'class' => 'count', 'type' => 'DL');
+my $desc_ref;
+my $result_file = "l1_mlog_stats.txt";
+my $match = 0;
+my %low_name  = ('type' => 'low latency');
+my %avg_name  = ('type' => 'avg latency');
+my %high_name = ('type' => 'high latency');
+
+(my $rc, my $fh) = open_read_text_file($result_file);
+if ($rc == 0 and defined $fh) {
+    my $num_sample = 0;
+
+    # A run may execute multiple tests. At this moment, only index FEC metrics of the
+    # designated test, specified by $log_test.
+
+    while (<$fh>) {
+        #  LATENCY_TASKNAME                         MIN  HIST_LOW       AVG  HIST_HIGH       MAX
+        #  GNB_DL_FEC_LINK       AVG (MU 0)     :  0.00     28.00     29.47      32.00     30.00
+        #  GNB_UL_FEC_LINK       AVG (MU 0)     :  0.00    160.00    160.46     162.00    160.00
+
+        # Skip until the log-test.
+        if ( $match == 0 ) {
+            if ( /$log_test/ ) {
+                $match = 1;
+                printf "Capture: %s\n", $_;
+            }
+            next;
+        }
+        if ( /GNB_DL_FEC_LINK *AVG/ || /GNB_UL_FEC_LINK *AVG/ ) {
+            my @latencies = split(/\s+/, $_);
+            if ( /GNB_UL_FEC_LINK *AVG/ ) {
+                $desc_ref = \%ul_desc;
+                printf "log: %s\n", $_;
+
+            } else {
+                $desc_ref = \%dl_desc;
+                printf "log: %s\n", $_;
+            }
+
+            my %s_low = ('begin' => $times{'begin'}, 'end' => $times{'end'}, 'value' => $latencies[7]);
+            my %s_avg = ('begin' => $times{'begin'}, 'end' => $times{'end'}, 'value' => $latencies[8]);
+            my %s_high = ('begin' => $times{'begin'}, 'end' => $times{'end'}, 'value' => $latencies[9]);
+
+            # Note, some tests have 0's FEC metrics. log_sample() rejects a sample with all 0's.
+
+            log_sample("flexran", $desc_ref, \%low_name, \%s_low);
+            log_sample("flexran", $desc_ref, \%avg_name, \%s_avg);
+            log_sample("flexran", $desc_ref, \%high_name, \%s_high);
+
+            $num_sample++;
+        }
+        if ( /Test:/ ) {
+            # The start of the next test. Skip it and the rest.
+            $match = 0 ;
+            $log_test = "EINVAL";
+            
+        }
+    } # while
+    close($fh);
+    printf "finishing_samples\n";
+    my $metric_data_name = finish_samples();
+    if ( $num_sample > 0 ) {
+        #my $metric_data_name = finish_samples();
+        # Associate the metrics with a benchmark-period (in this case "measurement")
+        my %sample;
+        my @periods;
+        my %period = ('name' => 'measurement');
+        $sample{'rickshaw-bench-metric'}{'schema'}{'version'} = "2021.04.12";
+        my @metric_files = ( $metric_data_name );
+        $period{'metric-files'} = \@metric_files;
+        push(@periods, \%period);
+        $sample{'periods'} = \@periods;
+        $sample{'primary-period'} = 'measurement';
+        $sample{'primary-metric'} = $primary_metric;
+        $rc = put_json_file("post-process-data.json", \%sample);
+        if ( $rc > 0 ) {
+            printf "flexran-post-process(): Could not write file post-process-data.json\n";
+            exit 1
+        }
+    }
+} else {
+    printf "flexran-post-process(): open_read_text_file() failed with return code %d for file %s\n", $rc, $result_file;
+    printf "Is the current directory for a flexran server (no result file)?\n";
+}
+# EOF

--- a/flexran-run-pic
+++ b/flexran-run-pic
@@ -1,0 +1,29 @@
+#!/bin/bash
+# mode will be set as LTE or 5G
+MODE=$1
+if [ "$MODE" == "LTE" ]; then
+	echo "Crucible does not support LTE"
+	exit 1
+
+elif [ "$MODE" != "5G" ]; then
+	echo "Crucible only support 5G"
+	exit 1
+fi
+
+source /opt/flexran_env_vars.sh
+#bash ./configure_cfg_files.sh
+
+
+if [ -n "$TESTFILE" ]; then
+    if [ "$TESTFILE" != "none" ]; then
+	    echo "CRU: invoke ./flexran-pic-l2 --testfile=${TESTFILE}"
+	    ./flexran-pic-l2 --testfile=${TESTFILE}
+    else
+	    echo "CRU: invoke ./flexran-pic-l2"
+	    ./flexran-pic-l2 
+    fi
+else
+	echo "CRU: invoke ./flexran-pic-l1 -e"
+	./flexran-pic-l1 -e
+fi
+

--- a/flexran-runtime
+++ b/flexran-runtime
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# defaults
+duration=1000
+
+longopts="duration:"
+opts=$(getopt -q -o "D:" --longoptions "$longopts" -n "getopt.sh" -- "$@");
+eval set -- "$opts";
+while true; do
+    case "$1" in
+        -D|--duration)
+            shift
+            duration=$1
+            shift
+            ;;
+        --)
+            shift;
+            break
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+#echo "$duration"
+echo 1200

--- a/rickshaw.json
+++ b/rickshaw.json
@@ -1,0 +1,42 @@
+{
+    "rickshaw-benchmark": {
+        "schema": {
+            "version": "2020.05.18"
+        }
+    },
+    "benchmark": "flexran",
+    "controller": {
+        "post-script": "%bench-dir%flexran-post-process"
+    },
+    "client": {
+        "files-from-controller": [
+            {
+                "src": "%bench-dir%/flexran-base",
+                "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/flexran-runtime",
+                "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/flexran-client",
+                "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%flexran-pic-l1",
+                "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/flexran-pic-l2",
+                "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/flexran-run-pic",
+                "dest": "/usr/bin/"
+            }
+         
+        ],
+        "runtime": "flexran-runtime",
+        "start": "flexran-client"
+    }
+}

--- a/workshop.json
+++ b/workshop.json
@@ -27,25 +27,6 @@
                "xz"
             ]
             }
-        },
-        {    
-	        "name": "flexran_src",
-	        "type": "manual",
-	        "manual_info": {
-		        "commands": [ 
-		            "curl  -o /opt/flexran-hello.sh http://perf1.perf.lab.eng.bos.redhat.com:9000/flexran-hello.sh"
-                ]
-	        }
-        },
-	    {
-	        "name": "flexran_bin",
-	        "type": "manual",
-	        "manual_info": {
-		        "commands": [ 
-		            "curl -o /opt/flexran-ls.sh http://perf1.perf.lab.eng.bos.redhat.com:9000/flexran-ls.sh"
-                ]
-	        }
         }
- 
     ]
 }

--- a/workshop.json
+++ b/workshop.json
@@ -1,0 +1,51 @@
+{
+    "workshop": {
+        "schema": {
+            "version": "2020.03.02"
+        }
+    },
+    "userenvs": [
+	    {
+	        "name": "default",
+	        "requirements": [
+                "dpdk_dependancies",
+                "flexran_src",
+                "flexran_bin"
+	        ]
+	    }
+    ],
+    "requirements": [
+	    {
+            "name": "dpdk_dependancies",
+            "type": "distro",
+            "distro_info": {
+            "packages": [
+               "numactl-devel",
+               "libhugetlbfs-devel",
+               "ethtool",
+               "net-tools",
+               "xz"
+            ]
+            }
+        },
+        {    
+	        "name": "flexran_src",
+	        "type": "manual",
+	        "manual_info": {
+		        "commands": [ 
+		            "curl  -o /opt/flexran-hello.sh http://perf1.perf.lab.eng.bos.redhat.com:9000/flexran-hello.sh"
+                ]
+	        }
+        },
+	    {
+	        "name": "flexran_bin",
+	        "type": "manual",
+	        "manual_info": {
+		        "commands": [ 
+		            "curl -o /opt/flexran-ls.sh http://perf1.perf.lab.eng.bos.redhat.com:9000/flexran-ls.sh"
+                ]
+	        }
+        }
+ 
+    ]
+}


### PR DESCRIPTION
Issue: Add flexran workload support to crucible.
Description:

- flexran-base: contains initial env checking before running workload
- flexran-client - this is the main module that launches L1 and Testmac processes and monitors completion
- flexran-pic-l1 - wrapper
- flexran-pic-l2 -  wrapper
- flexran-post-process - contains post processing functions to collect and index results to ES
- flexran-run-pic - wrapper
- flexran-runtime
- LICENSE
- README.md - will be enhanced with more details later
- rickshaw.json
- workshop.json

Limitations:
FlexRAN workshop builds just a skeleton container image w/o including FlexRAN S/W.  Intel FlexRAN distribution requires a complex build process: licensing, ICC compiler, DPDK and FLEXRAN reference S/W source.  In addition we are not clear on how to make available the FlexRAN binary blob. For now,  we build them outside crucible and copy the artifacts to worker node(s).

