### PR TITLE
Workshop: remove extraneous debug references

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -8,9 +8,7 @@
 	    {
 	        "name": "default",
 	        "requirements": [
-                "dpdk_dependancies",
-                "flexran_src",
-                "flexran_bin"
+                "dpdk_dependancies"
 	        ]
 	    }
     ],


### PR DESCRIPTION
The two entries used in devel were removed, but their references were not.