### PR TITLE
FlexRAN 20.11: add missing flexran_env_vars.sh

### DIFF
--- a/flexran-client
+++ b/flexran-client
@@ -48,8 +48,6 @@ function init_mount_fs {
     ln -s /tmp/opt/flexran /opt/flexran
     ln -s /tmp/opt/intel /opt/intel
     ln -s /tmp/opt/dpdk-20.11 /opt/dpdk-20.11
-    ln -s /tmp/opt/configure_cfg_files.sh /opt/configure_cfg_files.sh
-    ln -s /tmp/opt/flexran_env_vars.sh /opt/flexran_env_vars.sh
 }
 
 function set_fec_mode {

--- a/flexran-run-pic
+++ b/flexran-run-pic
@@ -11,8 +11,6 @@ elif [ "$MODE" != "5G" ]; then
 fi
 
 source /opt/flexran_env_vars.sh
-#bash ./configure_cfg_files.sh
-
 
 if [ -n "$TESTFILE" ]; then
     if [ "$TESTFILE" != "none" ]; then

--- a/flexran_env_vars.sh
+++ b/flexran_env_vars.sh
@@ -1,0 +1,16 @@
+export RTE_SDK=/opt/dpdk-20.11
+export RTE_TARGET=x86_64-native-linuxapp-icc
+export WIRELESS_SDK_TARGET_ISA=avx512
+export RPE_DIR=/opt/flexran/libs/ferrybridge
+export CPA_DIR=/opt/flexran/libs/cpa
+export ROE_DIR=/opt/flexran/libs/roe
+export XRAN_DIR=/opt/flexran/xran
+export DIR_WIRELESS_SDK_ROOT=/opt/flexran/sdk
+export SDK_BUILD=build-avx512-icc
+export DIR_WIRELESS_SDK=/opt/flexran/sdk/build-avx512-icc
+export FLEXRAN_SDK=/opt/flexran/sdk/build-avx512-icc/install
+export DIR_WIRELESS_FW=/opt/flexran/framework
+export DIR_WIRELESS_TEST_4G=/opt/flexran/tests/lte
+export DIR_WIRELESS_TEST_5G=/opt/flexran/tests/nr5g
+export DIR_WIRELESS_TABLE_5G=/opt/flexran/bin/nr5g/gnb/l1/table
+export LD_LIBRARY_PATH=/opt/intel/system_studio_2019/compilers_and_libraries_2019.5.281/linux/compiler/lib/intel64_lin:/opt/intel/system_studio_2019/compilers_and_libraries_2019.5.281/linux/ipp/lib/intel64:/opt/intel/system_studio_2019/compilers_and_libraries_2019.5.281/linux/compiler/lib/intel64_lin:/opt/intel/system_studio_2019/compilers_and_libraries_2019.5.281/linux/mkl/lib/intel64_lin:/opt/intel/system_studio_2019/compilers_and_libraries_2019.5.281/linux/tbb/lib/intel64/gcc4.7:/opt/intel/system_studio_2019/compilers_and_libraries_2019.5.281/linux/tbb/lib/intel64/gcc4.7:/opt/intel/system_studio_2019/debugger_2019/libipt/intel64/lib:/opt/intel/system_studio_2019/compilers_and_libraries_2019.5.281/linux/daal/lib/intel64_lin:/opt/intel/system_studio_2019/compilers_and_libraries_2019.5.281/linux/daal/../tbb/lib/intel64_lin/gcc4.4

--- a/rickshaw.json
+++ b/rickshaw.json
@@ -33,6 +33,10 @@
             {
                 "src": "%bench-dir%/flexran-run-pic",
                 "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/flexran_env_vars.sh",
+                "dest": "/opt/"
             }
          
         ],


### PR DESCRIPTION
Add missing file and cleanup a few lines of dead code